### PR TITLE
Use `git rev-parse HEAD` to get the current hash

### DIFF
--- a/gitbrute.go
+++ b/gitbrute.go
@@ -178,7 +178,7 @@ func getDate(h []byte, rx *regexp.Regexp) (d date, idx int) {
 }
 
 func curHash() string {
-	all, err := exec.Command("git", "show", "--format=format:%H").Output()
+	all, err := exec.Command("git", "rev-parse", "HEAD").Output()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The right command for the job, I think?
