### PR TITLE
Allow brute forcing empty commits

### DIFF
--- a/gitbrute.go
+++ b/gitbrute.go
@@ -78,7 +78,7 @@ func main() {
 	w := <-winner
 	close(done)
 
-	cmd := exec.Command("git", "commit", "--amend", "--date="+w.author.String(), "--file=-")
+	cmd := exec.Command("git", "commit", "--allow-empty", "--amend", "--date="+w.author.String(), "--file=-")
 	cmd.Env = append([]string{"GIT_COMMITTER_DATE=" + w.committer.String()}, os.Environ()...)
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = bytes.NewReader(msg)


### PR DESCRIPTION
Simply allow empty commits to be changed.

I like the first root commit of my repros to be an empty commit with a 0000000 prefix, however git errors if you try to amend an empty commit without --allow-empty.